### PR TITLE
[PR] Refactor: 네이버지도로 마이그레이션

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
+        "@types/navermaps": "^3.7.8",
         "@types/node": "^22.10.5",
         "@types/react": "^19.0.3",
         "@types/react-dom": "^19.0.2",
@@ -4689,6 +4690,12 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.7.tgz",
@@ -4986,6 +4993,15 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.3.tgz",
       "integrity": "sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg=="
+    },
+    "node_modules/@types/navermaps": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/@types/navermaps/-/navermaps-3.7.8.tgz",
+      "integrity": "sha512-LzQffMWcUfhKzOuPpUONaXmMN6sAkNf92q1nycRplqorIl2oDjgdPftOw0LttTS0/k/YsotizawK+PtcRWbuog==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.10.5",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     ]
   },
   "devDependencies": {
+    "@types/navermaps": "^3.7.8",
     "@types/node": "^22.10.5",
     "@types/react": "^19.0.3",
     "@types/react-dom": "^19.0.2",

--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
     -->
     <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
     <!--Kakao Map API-->
-    <!-- <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAOMAP_API_KEY%&libraries=services"></script> -->
+    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAOMAP_API_KEY%&libraries=services"></script>
     <!-- Naver Map API -->
     <script type="text/javascript" src="https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=%REACT_APP_NAVER_MAP_CLIENT_ID%&submodules=geocoder"></script>
   </head>

--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,9 @@
     -->
     <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
     <!--Kakao Map API-->
-    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAOMAP_API_KEY%&libraries=services"></script>
+    <!-- <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAOMAP_API_KEY%&libraries=services"></script> -->
+    <!-- Naver Map API -->
+    <script type="text/javascript" src="https://openapi.map.naver.com/openapi/v3/maps.js?clientId=%NAVER_MAP_CLIENT_ID_KEY%&submodules=geocoder"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
     <!--Kakao Map API-->
     <!-- <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAOMAP_API_KEY%&libraries=services"></script> -->
     <!-- Naver Map API -->
-    <script type="text/javascript" src="https://openapi.map.naver.com/openapi/v3/maps.js?clientId=%NAVER_MAP_CLIENT_ID_KEY%&submodules=geocoder"></script>
+    <script type="text/javascript" src="https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=%REACT_APP_NAVER_MAP_CLIENT_ID%&submodules=geocoder"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/main/EventMarker.tsx
+++ b/src/components/main/EventMarker.tsx
@@ -39,15 +39,24 @@ const EventMarker = ({ meeting, position, map }: EventMarkerProps) => {
       const content = ReactDOMServer.renderToString(
         <OverCard
           meeting={meeting}
-          onClose={withCloseButton ? closeInfoWindow : () => {}}
         />
       );
       
       infoWindow.setContent(content);
       infoWindow.open(map, marker);
 
-      if (withCloseButton) {
-        setTimeout(() => {
+      setTimeout(() => {
+        const contentDiv = document.querySelector('.bg-white.h-fit.cursor-pointer');
+        if (contentDiv) {
+          contentDiv.addEventListener('click', (e) => {
+            const target = e.target as HTMLElement;
+            if (!target.closest('[aria-label="Close"]')) {
+              window.location.href = `/meeting/detail/${meeting.id}`;
+            }
+          });
+        }
+
+        if (withCloseButton) {
           const closeButton = document.querySelector('.font-gmarket-bold[aria-label="Close"]');
           if (closeButton) {
             closeButton.addEventListener('click', (e) => {
@@ -56,8 +65,8 @@ const EventMarker = ({ meeting, position, map }: EventMarkerProps) => {
               closeInfoWindow();
             });
           }
-        }, 0);
-      }
+        }
+      }, 0);
     };
 
     naver.maps.Event.addListener(marker, 'click', () => {

--- a/src/components/main/EventMarker.tsx
+++ b/src/components/main/EventMarker.tsx
@@ -19,6 +19,7 @@ const EventMarker = ({ meeting, position, map }: EventMarkerProps) => {
       map
     });
 
+    // 네이버 지도의 정보창 설정 
     const infoWindow = new naver.maps.InfoWindow({
       content: '',
       backgroundColor: '#fff',
@@ -30,22 +31,27 @@ const EventMarker = ({ meeting, position, map }: EventMarkerProps) => {
       pixelOffset: new naver.maps.Point(0, -8)
     });
 
-    const showInfoWindow = (withCloseButton: boolean) => {
+    // InfoWindow 업데이트 및 표시
+    const showInfoWindow = () => {
       const closeInfoWindow = () => {
         infoWindow.close();
         isClickedRef.current = false;
       };
 
+      // OverCard를 문자열로 반환해서 InfoWindow 내용으로 설정
+      // InfoWindow가 리액트 컴포넌트를 직접 지원하지 않음
+      // 이후에 별도의 이벤트 리스너 추가
       const content = ReactDOMServer.renderToString(
         <OverCard
           meeting={meeting}
         />
       );
-      
+
       infoWindow.setContent(content);
       infoWindow.open(map, marker);
 
       setTimeout(() => {
+        // 컨텐츠 영역을 누른 경우, 상세 페이지로 이동
         const contentDiv = document.querySelector('.bg-white.h-fit.cursor-pointer');
         if (contentDiv) {
           contentDiv.addEventListener('click', (e) => {
@@ -56,27 +62,26 @@ const EventMarker = ({ meeting, position, map }: EventMarkerProps) => {
           });
         }
 
-        if (withCloseButton) {
-          const closeButton = document.querySelector('.font-gmarket-bold[aria-label="Close"]');
-          if (closeButton) {
-            closeButton.addEventListener('click', (e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              closeInfoWindow();
-            });
-          }
+        // 닫기 버튼을 누른 경우, InfoWindow 닫음
+        const closeButton = document.querySelector('.font-gmarket-bold[aria-label="Close"]');
+        if (closeButton) {
+          closeButton.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            closeInfoWindow();
+          });
         }
       }, 0);
     };
 
     naver.maps.Event.addListener(marker, 'click', () => {
       isClickedRef.current = true;
-      showInfoWindow(true);
+      showInfoWindow();
     });
 
     naver.maps.Event.addListener(marker, 'mouseover', () => {
       if (!isClickedRef.current && !infoWindow.getMap()) {
-        showInfoWindow(false);
+        showInfoWindow();
       }
     });
 

--- a/src/components/main/EventMarker.tsx
+++ b/src/components/main/EventMarker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { Meeting } from '../../types/models/meeting';
 import { MapPosition } from '../../types/models/common';
@@ -11,47 +11,45 @@ interface EventMarkerProps {
 }
 
 const EventMarker = ({ meeting, position, map }: EventMarkerProps) => {
-  const [isVisible, setIsVisible] = useState(false);
-
   useEffect(() => {
     const marker = new naver.maps.Marker({
       position: new naver.maps.LatLng(position.latitude, position.longitude),
       map
     });
 
-    const content = document.createElement('div');
-    content.innerHTML = ReactDOMServer.renderToString(
-      <OverCard
-        meeting={meeting}
-        onClose={() => null}
-        isMapOverlay={true}
-      />
-    );
+    const closeInfoWindow = () => {
+      infoWindow.close();
+    };
 
     const infoWindow = new naver.maps.InfoWindow({
-      content: content,
-      backgroundColor: "transparent",
-      borderColor: "transparent",
-      disableAnchor: true
+      content: ReactDOMServer.renderToString(
+        <OverCard
+          meeting={meeting}
+          onClose={closeInfoWindow}
+          isMapOverlay
+        />
+      ),
+      backgroundColor: '#fff',
+      borderColor: '#7C8BBE',
+      borderWidth: 1,
+      anchorSkew: true,
+      anchorSize: new naver.maps.Size(12, 12),
+      anchorColor: '#fff',
+      pixelOffset: new naver.maps.Point(0, -8)
     });
 
     naver.maps.Event.addListener(marker, 'click', () => {
-      setIsVisible(!isVisible);
-      if (infoWindow.getMap()) {
-        infoWindow.close();
-      } else {
-        infoWindow.open(map, marker);
-      }
+      infoWindow.open(map, marker);
     });
 
     naver.maps.Event.addListener(marker, 'mouseover', () => {
-      if (!isVisible) {
+      if (!infoWindow.getMap()) {
         infoWindow.open(map, marker);
       }
     });
 
     naver.maps.Event.addListener(marker, 'mouseout', () => {
-      if (!isVisible) {
+      if (!infoWindow.getMap()) {
         infoWindow.close();
       }
     });
@@ -60,9 +58,9 @@ const EventMarker = ({ meeting, position, map }: EventMarkerProps) => {
       marker.setMap(null);
       infoWindow.close();
     };
-  }, [meeting, position, map, isVisible]);
+  }, [meeting, position, map]);
 
-  return <></>;
+  return null;
 };
 
 export default EventMarker;

--- a/src/components/main/EventMarker.tsx
+++ b/src/components/main/EventMarker.tsx
@@ -42,9 +42,7 @@ const EventMarker = ({ meeting, position, map }: EventMarkerProps) => {
       // InfoWindow가 리액트 컴포넌트를 직접 지원하지 않음
       // 이후에 별도의 이벤트 리스너 추가
       const content = ReactDOMServer.renderToString(
-        <OverCard
-          meeting={meeting}
-        />
+        <OverCard meeting={meeting} />
       );
 
       infoWindow.setContent(content);
@@ -52,7 +50,7 @@ const EventMarker = ({ meeting, position, map }: EventMarkerProps) => {
 
       setTimeout(() => {
         // 컨텐츠 영역을 누른 경우, 상세 페이지로 이동
-        const contentDiv = document.querySelector('.bg-white.h-fit.cursor-pointer');
+        const contentDiv = document.querySelector('[data-overcard]');
         if (contentDiv) {
           contentDiv.addEventListener('click', (e) => {
             const target = e.target as HTMLElement;
@@ -63,7 +61,7 @@ const EventMarker = ({ meeting, position, map }: EventMarkerProps) => {
         }
 
         // 닫기 버튼을 누른 경우, InfoWindow 닫음
-        const closeButton = document.querySelector('.font-gmarket-bold[aria-label="Close"]');
+        const closeButton = document.querySelector('[data-button="close"]');
         if (closeButton) {
           closeButton.addEventListener('click', (e) => {
             e.preventDefault();

--- a/src/components/main/OverCard.tsx
+++ b/src/components/main/OverCard.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
-import { Meeting } from "../../types/models/meeting";
 import {
   Favorite,
   PeopleAlt,
@@ -9,7 +7,14 @@ import {
   RocketLaunch,
   LocationOn
 } from "@mui/icons-material";
+import { Meeting } from "../../types/models/meeting";
 import { toKoreanDuration, toKoreanRecruitmentType } from "../../util/transformKorean";
+
+interface OverCardProps {
+  meeting: Meeting;
+  onClose: () => void;
+  isMapOverlay?: boolean;
+}
 
 type IconTitleType = '관심' | '스택' | '마감' | '장소' | '인원' | '기간';
 
@@ -17,37 +22,19 @@ const IconComponent = ({ title }: { title: IconTitleType }) => {
   const iconStyle = { fontSize: 18, color: "#7C8BBE" };
 
   switch (title) {
-    case '관심':
-      return <Favorite sx={iconStyle} />;
-    case '스택':
-      return <RocketLaunch sx={iconStyle} />;
-    case '마감':
-      return <CalendarToday sx={iconStyle} />;
-    case '장소':
-      return <LocationOn sx={iconStyle} />;
-    case '인원':
-      return <PeopleAlt sx={iconStyle} />;
-    case '기간':
-      return <Timer sx={iconStyle} />;
-    default:
-      return null;
+    case '관심': return <Favorite sx={iconStyle} />;
+    case '스택': return <RocketLaunch sx={iconStyle} />;
+    case '마감': return <CalendarToday sx={iconStyle} />;
+    case '장소': return <LocationOn sx={iconStyle} />;
+    case '인원': return <PeopleAlt sx={iconStyle} />;
+    case '기간': return <Timer sx={iconStyle} />;
+    default: return null;
   }
 };
 
-interface ShotInformProps {
-  title: IconTitleType;
-  content: string;
-  unit?: string;
-}
-
-const ShotInform = ({ title, content, unit }: ShotInformProps) => {
+const ShotInform = ({ title, content, unit }: { title: IconTitleType; content: string; unit?: string }) => {
   const isPlace = title === "장소";
-  let displayContent = content;
-
-  if (isPlace) {
-    const match = content.match(/\(([^)]+)\)/);
-    displayContent = match ? match[1] : content;
-  }
+  const displayContent = isPlace ? (content.match(/\(([^)]+)\)/) ?? [null, content])[1] : content;
 
   return (
     <div className="flex flex-row items-center mb-2">
@@ -60,27 +47,13 @@ const ShotInform = ({ title, content, unit }: ShotInformProps) => {
   );
 };
 
-interface OverCardProps {
-  meeting: Meeting;
-  onClose: () => void;
-}
-
-function OverCard({ meeting, onClose }: OverCardProps) {
-  const navigate = useNavigate();
-  const {
-    id,
-    title,
-    recruitmentType,
-    maxParticipants,
-    duration,
-    endDate,
-    techStacks,
-    location,
-    likeDto: { likeCount }
-  } = meeting;
-
+function OverCard({ meeting, onClose, isMapOverlay = false }: OverCardProps) {
   const handleClick = () => {
-    navigate(`/meeting/detail/${id}`);
+    if (isMapOverlay) {
+      window.location.href = `/meeting/detail/${meeting.id}`;
+    } else {
+      window.location.href = `/meeting/detail/${meeting.id}`;
+    }
   };
 
   const handleClose = (e: React.MouseEvent) => {
@@ -98,18 +71,18 @@ function OverCard({ meeting, onClose }: OverCardProps) {
         <div className="w-full grid grid-cols-2 gap-1">
           <div className="col-span-2 flex justify-between items-start">
             <p className="text-bold mb-2 text-label font-gmarket-bold truncate max-w-[80%]">
-              [{toKoreanRecruitmentType(recruitmentType)}] {title}
+              [{toKoreanRecruitmentType(meeting.recruitmentType)}] {meeting.title}
             </p>
           </div>
-          <ShotInform title="관심" content={likeCount.toString()} />
-          <ShotInform title="인원" content={maxParticipants.toString()} unit="명" />
-          <ShotInform title="기간" content={toKoreanDuration(duration)} />
-          <ShotInform title="마감" content={endDate} />
+          <ShotInform title="관심" content={meeting.likeDto.likeCount.toString()} />
+          <ShotInform title="인원" content={meeting.maxParticipants.toString()} unit="명" />
+          <ShotInform title="기간" content={toKoreanDuration(meeting.duration)} />
+          <ShotInform title="마감" content={meeting.endDate} />
           <div className="col-span-2">
-            <ShotInform title="스택" content={techStacks.join(", ")} />
+            <ShotInform title="스택" content={meeting.techStacks.join(", ")} />
           </div>
           <div className="col-span-2">
-            <ShotInform title="장소" content={location} />
+            <ShotInform title="장소" content={meeting.location} />
           </div>
         </div>
         <button

--- a/src/components/main/OverCard.tsx
+++ b/src/components/main/OverCard.tsx
@@ -59,6 +59,7 @@ function OverCard({ meeting }: OverCardProps) {
 
   return (
     <div
+      data-overcard
       className="bg-white h-fit cursor-pointer box-content"
       style={{ width: 'max-content' }}
     >
@@ -81,6 +82,7 @@ function OverCard({ meeting }: OverCardProps) {
           </div>
         </div>
         <button
+          data-button="close"
           className="text-sub hover:text-bold self-start font-gmarket-bold ml-2 text-regular"
           aria-label="Close"
         >

--- a/src/components/main/OverCard.tsx
+++ b/src/components/main/OverCard.tsx
@@ -12,8 +12,6 @@ import { toKoreanDuration, toKoreanRecruitmentType } from "../../util/transformK
 
 interface OverCardProps {
   meeting: Meeting;
-  onClose: () => void;
-  isMapOverlay?: boolean;
 }
 
 type IconTitleType = '관심' | '스택' | '마감' | '장소' | '인원' | '기간';
@@ -47,18 +45,12 @@ const ShotInform = ({ title, content, unit }: { title: IconTitleType; content: s
   );
 };
 
-function OverCard({ meeting, onClose, isMapOverlay = false }: OverCardProps) {
-  const handleClick = () => {
-    if (isMapOverlay) {
-      window.location.href = `/meeting/detail/${meeting.id}`;
-    } else {
+function OverCard({ meeting }: OverCardProps) {
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    if (!target.closest('[aria-label="Close"]')) {
       window.location.href = `/meeting/detail/${meeting.id}`;
     }
-  };
-
-  const handleClose = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onClose();
   };
 
   return (
@@ -86,7 +78,6 @@ function OverCard({ meeting, onClose, isMapOverlay = false }: OverCardProps) {
           </div>
         </div>
         <button
-          onClick={handleClose}
           className="text-sub hover:text-bold self-start font-gmarket-bold ml-2 text-regular"
           aria-label="Close"
         >

--- a/src/components/main/OverCard.tsx
+++ b/src/components/main/OverCard.tsx
@@ -46,18 +46,10 @@ const ShotInform = ({ title, content, unit }: { title: IconTitleType; content: s
 };
 
 function OverCard({ meeting }: OverCardProps) {
-  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    const target = e.target as HTMLElement;
-    if (!target.closest('[aria-label="Close"]')) {
-      window.location.href = `/meeting/detail/${meeting.id}`;
-    }
-  };
-
   return (
     <div
       className="bg-white h-fit cursor-pointer box-content"
       style={{ width: 'max-content' }}
-      onClick={handleClick}
     >
       <div className="flex flex-row justify-between p-5">
         <div className="w-full grid grid-cols-2 gap-1">

--- a/src/components/main/OverCard.tsx
+++ b/src/components/main/OverCard.tsx
@@ -46,6 +46,17 @@ const ShotInform = ({ title, content, unit }: { title: IconTitleType; content: s
 };
 
 function OverCard({ meeting }: OverCardProps) {
+  const { 
+    recruitmentType,
+    title,
+    likeDto, 
+    maxParticipants, 
+    duration,
+    endDate, 
+    techStacks, 
+    location 
+  } = meeting;
+
   return (
     <div
       className="bg-white h-fit cursor-pointer box-content"
@@ -55,18 +66,18 @@ function OverCard({ meeting }: OverCardProps) {
         <div className="w-full grid grid-cols-2 gap-1">
           <div className="col-span-2 flex justify-between items-start">
             <p className="text-bold mb-2 text-label font-gmarket-bold truncate max-w-[80%]">
-              [{toKoreanRecruitmentType(meeting.recruitmentType)}] {meeting.title}
+              [{toKoreanRecruitmentType(recruitmentType)}] {title}
             </p>
           </div>
-          <ShotInform title="관심" content={meeting.likeDto.likeCount.toString()} />
-          <ShotInform title="인원" content={meeting.maxParticipants.toString()} unit="명" />
-          <ShotInform title="기간" content={toKoreanDuration(meeting.duration)} />
-          <ShotInform title="마감" content={meeting.endDate} />
+          <ShotInform title="관심" content={likeDto.likeCount.toString()} />
+          <ShotInform title="인원" content={maxParticipants.toString()} unit="명" />
+          <ShotInform title="기간" content={toKoreanDuration(duration)} />
+          <ShotInform title="마감" content={endDate} />
           <div className="col-span-2">
-            <ShotInform title="스택" content={meeting.techStacks.join(", ")} />
+            <ShotInform title="스택" content={techStacks.join(", ")} />
           </div>
           <div className="col-span-2">
-            <ShotInform title="장소" content={meeting.location} />
+            <ShotInform title="장소" content={location} />
           </div>
         </div>
         <button

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -16,7 +16,6 @@ const MainPage: React.FC = () => {
   
   const canShowMap = loaded && location?.latitude != null && location?.longitude != null;
 
-  // 지도 초기화
   useEffect(() => {
     if (!mapRef.current || !canShowMap || !window.naver) return;
 
@@ -37,25 +36,6 @@ const MainPage: React.FC = () => {
     };
   }, [canShowMap, location]);
 
-  // 마커 생성 및 클릭 이벤트 관리
-  useEffect(() => {
-    if (!naverMap) return;
-
-    meetings.forEach(meeting => {
-      const marker = new naver.maps.Marker({
-        position: new naver.maps.LatLng(meeting.latitude, meeting.longitude),
-        map: naverMap,
-        title: meeting.title,
-        clickable: true
-      });
-
-      naver.maps.Event.addListener(marker, 'click', () => {
-        console.log('마커 클릭:', meeting.title);
-      });
-    });
-
-  }, [naverMap, meetings]);
-
   const handlePageChange = (newPage: number) => {
     setPage(newPage);
   };
@@ -70,11 +50,19 @@ const MainPage: React.FC = () => {
         totalPages={totalPages}
         onPageChange={handlePageChange}
       />
-      <div 
-        ref={mapRef} 
-        id="map" 
-        style={{ width: "66%", height: "90vh", position: "fixed", right: 0 }}
-      />
+      <div ref={mapRef} id="map" style={{ width: "66%", height: "90vh", position: "fixed", right: 0 }}>
+        {naverMap && meetings.map((meeting) => (
+          <EventMarker
+            key={meeting.id}
+            meeting={meeting}
+            position={{
+              latitude: meeting.latitude,
+              longitude: meeting.longitude
+            }}
+            map={naverMap}
+          />
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Map as KakaoMap } from "react-kakao-maps-sdk";
 import EventMarker from "../components/main/EventMarker";
 import StudyList from "../components/main/StudyList";
@@ -6,14 +6,28 @@ import { useGeolocation } from '../hooks/common/useGeolocation';
 import { useMeetingList } from "../hooks/api/useMeeting";
 
 const MainPage: React.FC = () => {
+  const mapRef = useRef<HTMLDivElement>(null);
   const [page, setPage] = useState(1); 
   const { location, loaded } = useGeolocation();
   const { data, isLoading } = useMeetingList(page);
-
+  
   const meetings = data?.data.content || [];
   const totalPages = data?.data?.totalPages ?? 0;
-
+  
   const canShowMap = loaded && location?.latitude != null && location?.longitude != null;
+
+  useEffect(() => {
+    if (!mapRef.current || !canShowMap || !window.naver) return;
+
+    const map = new naver.maps.Map(mapRef.current, {
+      center: new naver.maps.LatLng(location?.latitude, location?.longitude),
+      zoom: 17
+    });
+
+    return () => {
+      map?.destroy();
+    }
+  }, [canShowMap, location]);
 
   const handlePageChange = (newPage: number) => {
     setPage(newPage);
@@ -29,7 +43,8 @@ const MainPage: React.FC = () => {
         totalPages={totalPages}
         onPageChange={handlePageChange}
       />
-      {canShowMap && (
+      <div ref={mapRef} id="map" style={{ width: "66%", height: "100%" }}/>
+      {/* {canShowMap && (
         <KakaoMap
           center={{ lat: location.latitude, lng: location.longitude }}
           style={{ width: "66%", height: "100%" }}
@@ -46,7 +61,7 @@ const MainPage: React.FC = () => {
             />
           ))}
         </KakaoMap>
-      )}
+      )} */}
     </div>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -50,7 +50,7 @@ const MainPage: React.FC = () => {
         totalPages={totalPages}
         onPageChange={handlePageChange}
       />
-      <div ref={mapRef} id="map" style={{ width: "66%", height: "90vh", position: "fixed", right: 0 }}>
+      <div ref={mapRef} id="map" style={{ width: "66%", position: "fixed", right: 0 }}>
         {naverMap && meetings.map((meeting) => (
           <EventMarker
             key={meeting.id}


### PR DESCRIPTION
<!---- 제목 emoji commitTag: name -->
<!---- [PR] ✨ Feat: login -->

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.  -->
- 다음 지도에서 네이버 지도로 마이그레이션

### 이슈 넘버
#39 

## PR 유형
어떤 변경 사항이 있나요?

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [x]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 의논할 부분
- 기존 주소 검색을 [다음 주소 검색](https://postcode.map.daum.net/guide)을 사용
  - 이를 네이버 [Geocoder를 활용한 주소와 좌표 검색 API 호출하기](https://navermaps.github.io/maps.js.ncp/docs/tutorial-Geocoder-Geocoding.html)로 변경하려 함
  - 그러나 해당 기능은 창으로 주소를 입력하지 않음
  - 사용자에게 직관적이지 않을 것이라 생각 
-> 주소 검색은 다음 지도 유지하도록 코드 변경 X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - 새로운 개발 종속성 `@types/navermaps`가 추가되었습니다.
- **New Features**
  - Naver Map API 연동을 위해 index.html에 스크립트 태그가 적용되었습니다.
  - 메인 페이지와 회의 생성 페이지에서 지도 기능이 Kakao Maps에서 Naver Maps로 전환되었습니다.
- **Refactor**
  - 지도 관련 컴포넌트의 이벤트 처리 및 상태 관리가 최적화되었습니다.
  - 마커와 정보 카드 인터랙션 로직이 개선되어 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->